### PR TITLE
assume underbar suffix for env prefix

### DIFF
--- a/lib/plugins/env.js
+++ b/lib/plugins/env.js
@@ -6,6 +6,7 @@
 
 module.exports = function(prefix){
   prefix = prefix || '';
+  if (prefix && /[^_]$/.test(prefix)) prefix += '_';
   return function(key, val){
     var name = prefix + key.toUpperCase().split(' ').join('_');
     return process.env[name] || val;

--- a/test/env.js
+++ b/test/env.js
@@ -20,4 +20,10 @@ describe('env(prefix)', function(){
     process.env.NB_DEV_UI = 'yes';
     fn('dev ui', 'no').should.equal('yes');
   })
+
+  it('should append underbar', function(){
+    var fn = env('NB');
+    process.env.NB_DEV_UI = 'yes';
+    fn('dev ui', 'no').should.equal('yes');
+  });
 })


### PR DESCRIPTION
When doing:

``` js
eson.env('GJ')
```

I assumed it would look for:

``` sh
GJ_KEYNAME = "...";
```

If no prefix is there, obviously this would not be the case... Seem reasonable?
