### PR TITLE
Parser accessor

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -60,7 +60,7 @@ Parser.prototype.clone = function(){
 
 Parser.prototype.read = function(path){
   this.path = path;
-  if (!~path.indexOf('.json')) path += '.json';
+  if (!~path.indexOf(this.format.extname)) path += this.format.extname;
   return this.parse(fs.readFileSync(path, 'utf8'));
 };
 
@@ -100,6 +100,7 @@ Parser.prototype.parse = function(str){
  */
 
 Parser.prototype.format = {
+  extname: '.json',
   parse: JSON.parse,
   stringify: JSON.stringify
 };

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -74,11 +74,12 @@ Parser.prototype.read = function(path){
 
 Parser.prototype.parse = function(str){
   var self = this
-    , plugins = this.plugins;
+    , plugins = this.plugins
+    , format = this.format;
 
-  if (typeof str !== 'string') str = JSON.stringify(str);
+  if (typeof str !== 'string') str = format.stringify(str);
 
-  return JSON.parse(str, function(key, val){
+  return format.parse(str, function(key, val){
     var plugin, ret;
     if ('' === key) return val;
     for (var i = 0, len = plugins.length; i < len; ++i) {
@@ -88,4 +89,17 @@ Parser.prototype.parse = function(str){
     }
     return val;
   });
+};
+
+/**
+ * The parser's serialization format.
+ * By default, exposes the JSON API, but not the actual object,
+ * so that individual methods may be overwritten.
+ *
+ * @api public
+ */
+
+Parser.prototype.format = {
+  parse: JSON.parse,
+  stringify: JSON.stringify
 };

--- a/test/parser.js
+++ b/test/parser.js
@@ -85,4 +85,35 @@ describe('Parser', function(){
       parser.parse(data).should.eql(data);
     })
   })
+
+  describe('.format', function() {
+    it('should expose the JSON api by default', function() {
+      var parser = new Parser
+        , format = parser.format;
+
+      format.parse.should.equal(JSON.parse);
+      format.stringify.should.equal(JSON.stringify);
+    })
+
+    it('should not be the JSON global', function() {
+      var parser = new Parser
+        , format = parser.format;
+
+      format.should.not.equal(JSON);
+    })
+
+    it('should accept a custom format object', function() {
+      var parser = new Parser;
+
+      parser.format = {
+        parse: function(str) {
+          return JSON.parse(str.toUpperCase());
+        },
+        stringify: JSON.stringify
+      };
+
+      parser.parse('{ "foo": "bar" }')
+        .should.eql({ FOO: 'BAR' });
+    })
+  })
 })


### PR DESCRIPTION
This patch makes the serialization format for the eson Parser configurable. Users may provide their own `parse` and `stringify` methods. This would allow one to swap in another implementation like [json5](http://json5.org/), for instance.
